### PR TITLE
certbot-route53.sh: fix self-link when called with abs path

### DIFF
--- a/certbot-route53.sh
+++ b/certbot-route53.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+MYSELF="$(cd $(dirname "$0") && pwd)/$(basename $0)"
+
 if [ -z $CERTBOT_DOMAIN ]; then
   mkdir -p $PWD/letsencrypt
 
   certbot certonly \
     --non-interactive \
     --manual \
-    --manual-auth-hook $PWD/$0 \
-    --manual-cleanup-hook $PWD/$0 \
+    --manual-auth-hook "$MYSELF" \
+    --manual-cleanup-hook "$MYSELF" \
     --preferred-challenge dns \
     --config-dir $PWD/letsencrypt \
     --work-dir $PWD/letsencrypt \


### PR DESCRIPTION
Previously, `certbot-route53.sh` would fail when called with an absolute
path (e.g., `/opt/certbot-route53/certbot-route53.sh`), because it would
prepend the working directory in front of the absolute path.

This would generate an error message like the following:
```
Unable to find manual-auth-hook command /home/user//opt/certbot-route53/certbot-route53.sh in the PATH.
```

The approach in this PR should hopefully be robust to either relative or
absolute invocations of the script.