### PR TITLE
Fix route53 query

### DIFF
--- a/certbot-route53.sh
+++ b/certbot-route53.sh
@@ -19,7 +19,7 @@ if [ -z $CERTBOT_DOMAIN ]; then
 else
   [[ $CERTBOT_AUTH_OUTPUT ]] && ACTION="DELETE" || ACTION="UPSERT"
 
-  printf -v QUERY 'HostedZones[?ends_with(`%s.`,Name)].Id' $CERTBOT_DOMAIN
+  printf -v QUERY 'HostedZones[?Name == `%s.`]|[?Config.Privatezone != `false`].Id' "${CERTBOT_DOMAIN}"
 
   HOSTED_ZONE_ID=$(aws route53 list-hosted-zones --query $QUERY --output text)
 
@@ -44,6 +44,6 @@ else
       }]
     }"
   )
-  
+
   echo 1
 fi

--- a/certbot-route53.sh
+++ b/certbot-route53.sh
@@ -1,49 +1,49 @@
 #!/usr/bin/env bash
 
-MYSELF="$(cd $(dirname "$0") && pwd)/$(basename $0)"
+MYSELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 
-if [ -z $CERTBOT_DOMAIN ]; then
-  mkdir -p $PWD/letsencrypt
+if [ -z "${CERTBOT_DOMAIN}" ]; then
+  mkdir -p "${PWD}/letsencrypt"
 
   certbot certonly \
     --non-interactive \
     --manual \
-    --manual-auth-hook "$MYSELF" \
-    --manual-cleanup-hook "$MYSELF" \
+    --manual-auth-hook "${MYSELF}" \
+    --manual-cleanup-hook "${MYSELF}" \
     --preferred-challenge dns \
-    --config-dir $PWD/letsencrypt \
-    --work-dir $PWD/letsencrypt \
-    --logs-dir $PWD/letsencrypt \
-    $@
+    --config-dir "${PWD}/letsencrypt" \
+    --work-dir "${PWD}/letsencrypt" \
+    --logs-dir "${PWD}/letsencrypt" \
+    "$@"
 
 else
-  [[ $CERTBOT_AUTH_OUTPUT ]] && ACTION="DELETE" || ACTION="UPSERT"
+  [[ ${CERTBOT_AUTH_OUTPUT} ]] && ACTION="DELETE" || ACTION="UPSERT"
 
   printf -v QUERY 'HostedZones[?Name == `%s.`]|[?Config.Privatezone != `false`].Id' "${CERTBOT_DOMAIN}"
 
-  HOSTED_ZONE_ID=$(aws route53 list-hosted-zones --query $QUERY --output text)
+  HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query "${QUERY}" --output text)"
 
-  if [ -z $HOSTED_ZONE_ID ]; then
-    echo "No hosted zone found that matches $CERTBOT_DOMAIN"
+  if [ -z "${HOSTED_ZONE_ID}" ]; then
+    echo "No hosted zone found that matches ${CERTBOT_DOMAIN}"
     exit 1
   fi
 
-  aws route53 wait resource-record-sets-changed --id $(
+  aws route53 wait resource-record-sets-changed --id "$(
     aws route53 change-resource-record-sets \
-    --hosted-zone-id $HOSTED_ZONE_ID \
+    --hosted-zone-id "${HOSTED_ZONE_ID}" \
     --query ChangeInfo.Id --output text \
     --change-batch "{
       \"Changes\": [{
-        \"Action\": \"$ACTION\",
+        \"Action\": \"${ACTION}\",
         \"ResourceRecordSet\": {
-          \"Name\": \"_acme-challenge.$CERTBOT_DOMAIN.\",
-          \"ResourceRecords\": [{\"Value\": \"\\\"$CERTBOT_VALIDATION\\\"\"}],
+          \"Name\": \"_acme-challenge.${CERTBOT_DOMAIN}.\",
+          \"ResourceRecords\": [{\"Value\": \"\\\"${CERTBOT_VALIDATION}\\\"\"}],
           \"Type\": \"TXT\",
           \"TTL\": 30
         }
       }]
     }"
-  )
+  )"
 
   echo 1
 fi


### PR DESCRIPTION
The old AWS Route53 query can lead to obtain several zones, per example, if you have these zones in Route53:

- my.example.com
- example.com

And you run the script for the domain `example.com` the old query would have returned both of them (as all of them "ends_with"  `example.com`).

Also, in Route53 you can have private zones, you can't use Letsencrypt with those as it is impossible for Letsencrypt to verify the TXT record. Also, in case that you have two zones with the same domain but one is private and the other one public, you _want_ to use the public one (then you can use the generated certificate for the internal one, which is cool).

The second commit are the style changes that [Shellcheck](https://www.shellcheck.net/) requires. Not strictly necessary, but for safety and to avoid errors with bad inputs is good to apply them.